### PR TITLE
Fix bug of some IMEs cannot input in terminal

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/xterm.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/xterm.css
@@ -62,7 +62,7 @@
 }
 
 .xterm .xterm-helper-textarea {
-	padding: 0;
+/* 	padding: 0; */
 	border: 0;
 	margin: 0;
 	/* Move textarea out of the screen to the far left, so that the cursor is not visible */


### PR DESCRIPTION
QQ pinyin and [Rime(小狼毫)](https://github.com/rime/weasel) input method cannot input character in terminal because of the css padding: 0; in .xterm-helper-textarea, but some other IMEs(like sogou pinyin) are still unable to input characters for some other reason.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #115814
QQ pinyin and Rime IME cannot input character in terminal
thanks to @ccloli and @ZhyMC